### PR TITLE
fix: wrong resource languages

### DIFF
--- a/src/main/resources/org/fife/rsta/ui/search/Search_it.properties
+++ b/src/main/resources/org/fife/rsta/ui/search/Search_it.properties
@@ -3,7 +3,7 @@ ReplaceDialogTitle=Sostituisci
 
 Direction=Direzione:
 Up=Su
-Down=Gi\u00e0
+Down=Gi\u00F9
 UpMnemonic=U
 DownMnemonic=G
 
@@ -21,7 +21,7 @@ ReplaceWith.Mnemonic=S
 
 Find=Trova
 Replace=Sostituisci
-ReplaceAll=sostituisci tutto
+ReplaceAll=Sostituisci tutto
 MarkAll=Segna tutto
 Cancel=Annulla
 Find.Mnemonic=T


### PR DESCRIPTION
fixed "Down" string in italian language, from "Gi\u00e0" to "Gi\u00F9"
mod "ReplaceAll" string value with the first character in uppercase for the italian language, from "sostituisci tutto" to "Sostituisci tutto"