### PR TITLE
Use real Maven dependencies on sister projects, fixes #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,8 @@ For more information, visit [http://bobbylight.github.io/RSyntaxTextArea/](http:
 ## Compiling
 
 RSTAUI is built using Gradle.  To compile the source, run all tests, and build the distribution jar,
-you must check out RSTAUI and its sister projects, `RSyntaxTextArea` and `AutoComplete`, side by side.
-Then use Gradle to build:
+simply change into the project directory and run:
 
-    cd RSyntaxTextArea
-    gradlew build
-    cd ../AutoComplete
-    gradlew build
-    cd ../RSTAUI
     gradlew build --warning-mode all
 
 ## Example Usage

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ group 'com.fifesoft'
 allprojects {
 
     repositories {
+        mavenLocal()
         mavenCentral()
         maven {
             url 'https://oss.sonatype.org/content/repositories/snapshots'
@@ -37,11 +38,8 @@ subprojects {
     }
 
     dependencies {
-        // Paths are relative to submodules
-        implementation files("${projectDir.absolutePath}/../../RSyntaxTextArea/RSyntaxTextArea/build/classes/java/main")
-        implementation files("${projectDir.absolutePath}/../../RSyntaxTextArea/RSyntaxTextArea/build/resources/main")
-        implementation files("${projectDir.absolutePath}/../../AutoComplete/AutoComplete/build/classes/java/main")
-        implementation files("${projectDir.absolutePath}/../../AutoComplete/AutoComplete/build/resources/main")
+        implementation 'com.fifesoft:rsyntaxtextarea:3.0.8-SNAPSHOT'
+        implementation 'com.fifesoft:autocomplete:3.0.4'
         testImplementation 'junit:junit:4.12'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
     }
 
     dependencies {
-        implementation 'com.fifesoft:rsyntaxtextarea:3.0.8-SNAPSHOT'
+        implementation 'com.fifesoft:rsyntaxtextarea:3.0.8'
         implementation 'com.fifesoft:autocomplete:3.0.4'
         testImplementation 'junit:junit:4.12'
     }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -58,7 +58,7 @@
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
     <module name="Translation"/>
-    
+
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="FileLength">
@@ -212,9 +212,9 @@
         <module name="UpperEll"/>
 
     </module>
-	
+
 	<module name="SuppressionFilter">
-		<property name="file" value="config/checkstyle/rstauiSuppressions.xml"/>
+		<property name="file" value="${config_loc}/rstauiSuppressions.xml"/>
 	</module>
 
 </module>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
 javaVersion=1.8
-version=3.0.4-SNAPSHOT
+version=3.0.4


### PR DESCRIPTION
This change updates the build configuration to properly capture the
dependency on two sister projects within the Gradle build process
itself. This also means that the build process is much simpler for
people who wish to contribute changes to this project; they no longer
need to check out or build the sister projects, as that is taken care
of by the Maven infrastructure.

I have also verified that this change fixes the generated `pom.xml` so
that client projects will automatically know they need to have
RSyntaxTextarea and AutoComplete on the class path. Beat Link Trigger
no longer crashes when I depend on this snapshot version, as it did
when I depended on 3.0.3.

To test against a local (not yet published) snapshot of one of the
sister projects, all you need to do is configure this project to
depend on the snapshot version, and then run `gradlew
publishToMavenLocal` in the sister project you want to test against.

I also had to make the same fix I made in RSyntaxTextArea so that the
checkStyle configuration file could be located in a cross-platform way.
You will probably need to do the same thing in AutoComplete.

Before releasing this, version 3.0.8 of RSyntaxTextArea must be
released, and this `build.gradle` needs to be updated to depend on the
released version.