### PR TITLE
Add `setSearchListener()` method in `FindDialog` and `ReplaceDialog`

### DIFF
--- a/RSTAUI/src/main/java/org/fife/rsta/ui/search/FindDialog.java
+++ b/RSTAUI/src/main/java/org/fife/rsta/ui/search/FindDialog.java
@@ -229,6 +229,14 @@ public class FindDialog extends AbstractFindReplaceDialog {
 
 
 	/**
+	 * @param listener The component that listens for {@link SearchEvent}s.
+	 */
+	public void setSearchListener(SearchListener listener){
+		this.searchListener = listener;
+	}
+
+
+	/**
 	 * Listens for changes in the text field (find search field).
 	 */
 	private class FindDocumentListener implements DocumentListener {

--- a/RSTAUI/src/main/java/org/fife/rsta/ui/search/ReplaceDialog.java
+++ b/RSTAUI/src/main/java/org/fife/rsta/ui/search/ReplaceDialog.java
@@ -509,6 +509,14 @@ public class ReplaceDialog extends AbstractFindReplaceDialog {
 
 
 	/**
+	 * @param listener The component that listens for {@link SearchEvent}s.
+	 */
+	public void setSearchListener(SearchListener listener){
+		this.searchListener = listener;
+	}
+
+
+	/**
 	 * Listens for changes in the text field (find search field).
 	 */
 	private class ReplaceDocumentListener implements DocumentListener {


### PR DESCRIPTION
`FindDialog` and `ReplaceDialog` both extend `AbstractFindReplaceDialog` but they both have their own `searchListener` field. Neither use the `AbstractFindReplaceDialog.listenerList` field, so the`addSearchListener()` and `removeSearchListener()` methods do not work as expected.